### PR TITLE
Fix vanished menu in some cases

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -46,7 +46,7 @@
 					<h5>致我们终（yi）将（jing）逝去的青春</h5>
 				</div>
 				<div class="data-info">
-					<div class="list-group list-group-horizontal">
+					<div class="list-group list-group-horizontal" style="margin-bottom:200px;">
 						<%if(user.messages > 0){%>
 							<a href="messages/index.html" class="list-group-item list-group-item-action">
 								说说<span class="badge badge-primary badge-pill"><%:=user.messages%></span>


### PR DESCRIPTION
我的屏幕是1920*1080放大175%，出现了主页下方菜单栏被浮动footer遮挡。简单尝试后，用一个直接方法，即强制添加200px的margin-bottom来修补这个问题。