### PR TITLE
Fix vanished menu v2

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -46,7 +46,7 @@
 					<h5>致我们终（yi）将（jing）逝去的青春</h5>
 				</div>
 				<div class="data-info">
-					<div class="list-group list-group-horizontal" style="margin-bottom:200px;">
+					<div class="list-group list-group-horizontal">
 						<%if(user.messages > 0){%>
 							<a href="messages/index.html" class="list-group-item list-group-item-action">
 								说说<span class="badge badge-primary badge-pill"><%:=user.messages%></span>
@@ -88,6 +88,9 @@
 							</a>
 						<%}%>
 					</div>
+				</div>
+				<div style="padding-bottom: 2rem;">
+					<span class="text-white"> &nbsp;</span>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
在菜单下方添加与footer高度一致的空白，确保在各种放大倍数下屏幕下方菜单栏不被遮挡。

很不好意思，在没有经过大量尝试的情况下就做出了第一个commit和pull request（毕竟直接加margin-bottom把页面高度撑开可谓是偷懒的第一直觉，也原谅我并非精进前端三件套😂）。
 在各种放大倍数上margin-bottom的工作效果不尽一致，例如1920*1080下：
100%无问题 
125%被遮挡 margin-bottom不起效果
150%被遮挡 margin-bottom有效果

所以最终考虑了一个比较通用全面的方法来解决。