### PR TITLE
fix:获取访客时，服务器返回5xx错误可能会导致无限重试的问题

### DIFF
--- a/src/js/modules/visitors.js
+++ b/src/js/modules/visitors.js
@@ -97,6 +97,12 @@ API.Visitors.getAllList = async() => {
             return await arguments.callee.apply(undefined, [nextPageIndex]);
         }).catch(async(e) => {
             console.error("获取访客列表异常，当前页：", nextPageIndex, e);
+            // PATCH: 如果服务器错误，则判断页数再进入重试
+            if (nextPageIndex >= QZone.Visitors.Data.totalPage) {
+              // 最后一页停止获取
+              return QZone.Visitors.Data;
+            }
+
             // 当前页失败后，跳过继续请求下一页
             // 递归获取下一页
             // 请求一页成功后等待一秒再请求下一页


### PR DESCRIPTION
在备份访客数据时，腾讯服务器可能会返回5xx错误，进入到API的reject流程。
原逻辑中对reject的处理是直接下一页，如果一直没有进入then，则一直下一页。
PR中增加了对reject的页码判断处理。